### PR TITLE
Fix for flycheck

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -252,7 +252,7 @@ This segment overrides the modeline functionality of `org-pomodoro' itself."
      (defmacro spaceline--flycheck-face (state)
        "Generate a face for the given flycheck error type STATE."
        (let* ((fname (intern (format "spaceline-flycheck-%S-face" state)))
-              (foreground (face-foreground (intern (format "flycheck-fringe-%S" state)))))
+              (foreground (face-foreground (intern (format "flycheck-fringe-%S" state)) nil t)))
          `(progn
             (defface ,fname '((t ()))
               ,(format "Face for flycheck %S feedback in modeline." state)

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -247,20 +247,20 @@ This segment overrides the modeline functionality of `org-pomodoro' itself."
       str))
   :when (bound-and-true-p eyebrowse-mode))
 
-(defmacro spaceline--flycheck-face (state)
-  "Generate a face for the given flycheck error type STATE."
-  (let* ((fname (intern (format "spaceline-flycheck-%S-face" state)))
-         (foreground (face-foreground (intern (format "flycheck-fringe-%S" state)))))
-    `(progn
-       (defface ,fname '((t ()))
-         ,(format "Face for flycheck %S feedback in modeline." state)
-         :group 'spaceline)
-       (set-face-attribute ',fname nil
-                           :foreground ,foreground
-                           :box (face-attribute 'mode-line :box)))))
-
 (eval-after-load 'flycheck
   '(progn
+     (defmacro spaceline--flycheck-face (state)
+       "Generate a face for the given flycheck error type STATE."
+       (let* ((fname (intern (format "spaceline-flycheck-%S-face" state)))
+              (foreground (face-foreground (intern (format "flycheck-fringe-%S" state)))))
+         `(progn
+            (defface ,fname '((t ()))
+              ,(format "Face for flycheck %S feedback in modeline." state)
+              :group 'spaceline)
+            (set-face-attribute ',fname nil
+                                :foreground ,foreground
+                                :box (face-attribute 'mode-line :box)))))
+
      (spaceline--flycheck-face error)
      (spaceline--flycheck-face warning)
      (spaceline--flycheck-face info)))


### PR DESCRIPTION
- Fix byte-compile time macro expansion issue(257822956d945d7ec90e2192c04fa880669c7ed3)
- Set inherit flag of `face-foreground`(e5e9b5230fa340f7f870298429b8de2d2d6f7e30)

I got following error when byte-compiling spaceline-segments.el.

```
spaceline-segments.el:262:1:Error: Invalid face: flycheck-fringe-error
```
