### PR TITLE
Adds segment to show projectile root if available

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -247,6 +247,15 @@ Supports both Emacs and Evil cursor conventions."
 (defvar pyvenv-virtual-env)
 (defvar pyvenv-virtual-env-name)
 
+(defcustom spaceline-projectile-segment-fence
+  '(right " ⟩")
+  "Text to show on either side of the projectile root."
+  :options '(left right)
+  :type '(plist :value-type string)
+  :group 'projectile)
+
+(declare-function projectile-project-p 'projectile)
+(declare-function projectile-project-name 'projectile)
 (declare-function anzu--update-mode-line 'anzu)
 (declare-function evil-state-property 'evil-common)
 (declare-function eyebrowse--get 'eyebrowse)
@@ -259,6 +268,16 @@ Supports both Emacs and Evil cursor conventions."
 (declare-function window-numbering-get-number 'window-numbering)
 (declare-function pyenv-mode-version 'pyenv-mode)
 (declare-function pyenv-mode-full-path 'pyenv-mode)
+
+(spaceline-define-segment projectile-root
+  "Show the current projectile root."
+  (concat (plist-get spaceline-projectile-segment-fence 'left)
+          (projectile-project-name)
+          (plist-get spaceline-projectile-segment-fence 'right))
+  :when (and (fboundp 'projectile-project-p)
+             (stringp (projectile-project-p))
+             (not (string-equal (projectile-project-name) (buffer-name))))
+  :global-override projectile-mode-line)
 
 (spaceline-define-segment anzu
   "Show the current match number and the total number of matches.  Requires anzu

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -248,10 +248,9 @@ Supports both Emacs and Evil cursor conventions."
 (defvar pyvenv-virtual-env-name)
 
 (defcustom spaceline-projectile-segment-fence
-  '(right " ⟩")
-  "Text to show on either side of the projectile root."
-  :options '(left right)
-  :type '(plist :value-type string)
+  '("" " ⟩")
+  "Text to display on either side of the current projectile root."
+  :type '(list (string :tag " Left") (string :tag "Right"))
   :group 'projectile)
 
 (declare-function projectile-project-p 'projectile)
@@ -271,9 +270,9 @@ Supports both Emacs and Evil cursor conventions."
 
 (spaceline-define-segment projectile-root
   "Show the current projectile root."
-  (concat (plist-get spaceline-projectile-segment-fence 'left)
+  (concat (car spaceline-projectile-segment-fence)
           (projectile-project-name)
-          (plist-get spaceline-projectile-segment-fence 'right))
+          (cadr spaceline-projectile-segment-fence))
   :when (and (fboundp 'projectile-project-p)
              (stringp (projectile-project-p))
              (not (string-equal (projectile-project-name) (buffer-name))))


### PR DESCRIPTION
I incorporate this into my segments like so:
`((projectile-root buffer-id) remote-host))`

I prefer minimal text fencing and this seems to fit the overall Spacemacs aesthetic, so with this PR incorporated as above, the default looks like this:
`my-project ⟩ my-project-tests.el`

But this is customizable, so you could easily get something instead like
`my-project-tests.el in Projectile[my-project]`
by transposing the order of `projectile-root` & `buffer-id` and setting `spaceline-projectile-segment-fence` to `'("in Projectile[" "]")`