### PR TITLE
Check that the face-funcs actually return a face

### DIFF
--- a/spaceline.el
+++ b/spaceline.el
@@ -94,13 +94,15 @@ This variable supersedes `spaceline-highlight-face-func' if set.")
 FACE and ACTIVE have the same meanings as in `spaceline-face-func'. Delegates
 the work to `spaceline-face-func' if it is given, otherwise falls back to
 default configuration."
-  (if spaceline-face-func
+  (if (and spaceline-face-func
+           (facep (funcall spaceline-face-func face active)))
       (funcall spaceline-face-func face active)
     (cond
      ((eq 'face1 face) (if active 'powerline-active1 'powerline-inactive1))
      ((eq 'face2 face) (if active 'mode-line 'mode-line-inactive))
      ((eq 'line face) (if active 'powerline-active2 'powerline-inactive2))
-     ((eq 'highlight face) (if active
+     ((eq 'highlight face) (if (and active
+                                    (facep (funcall spaceline-highlight-face-func)))
                                (funcall spaceline-highlight-face-func)
                              'powerline-inactive1)))))
 


### PR DESCRIPTION
Otherwise the whole mode-line fails for a bad face function

Fixes an issue in spacemacs where the mode-line disappears if you disable `evil-local-mode`, for example.