### PR TITLE
Add segment for input method

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -46,6 +46,7 @@
    `((battery :when active)
      (python-pyvenv :fallback python-pyenv)
      selection-info
+     input-method
      ((buffer-encoding-abbrev
        point-position
        line-column)

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -171,6 +171,34 @@ Supports both Emacs and Evil cursor conventions."
             (and (bound-and-true-p evil-local-mode)
                  (eq 'visual evil-state))))
 
+(defcustom spaceline-show-default-input-method nil
+  "Whether to show the default input method in `input-method'.
+
+When non-nil, show the default input method in the `input-method'
+segment.  Otherwise only show the active input method, if any."
+  :type 'boolean
+  :group 'spaceline
+  :risky t)
+
+(spaceline-define-segment input-method
+  "The current input method, or the default input method."
+  (cond
+   (current-input-method
+    (propertize current-input-method-title 'face 'bold))
+   ;; `evil-input-method' is where evil remembers the input method while in
+   ;; normal state.  The input method is not active in normal state, but Evil
+   ;; will enable this input method again when switching to insert/emacs state.
+   ((and (bound-and-true-p evil-mode) (bound-and-true-p evil-input-method))
+    (nth 3 (assoc default-input-method input-method-alist)))
+   ((and spaceline-show-default-input-method default-input-method)
+     (propertize (nth 3 (assoc default-input-method input-method-alist))
+                 'face 'italic)))
+  :when (or current-input-method
+            (and (bound-and-true-p evil-mode)
+                 (bound-and-true-p evil-input-method))
+            (and spaceline-show-default-input-method
+                 default-input-method)))
+
 (spaceline-define-segment hud
   "A HUD that shows which part of the buffer is currently visible."
   (powerline-hud highlight-face default-face)


### PR DESCRIPTION
See #45.  I've added the segment after `selection-info`, but I'm not sure whether that's the right place.  

The segment shows the current input method if any is active, and supports Evil Mode (which disables the input method in normal mode and remembers it in a special variable).

If no current input method is set the segment shows the default input method.  That's the input method that becomes active when you toggle the input method without prefix argument.  I'm not sure how useful that information is, because a user would typically customise this option explicitly and thus know what input method they have enabled.  I've included it for completeness, but I can also remove it if you want.
