### PR TITLE
Add mu4e-alert segment to show unread mails

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -37,6 +37,7 @@
      (((minor-modes :separator spaceline-minor-modes-separator)
        process)
       :when active)
+     (mu4e-alert-segment :when active)
      (erc-track :when active)
      (version-control :when active)
      (org-pomodoro :when active)

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -535,7 +535,7 @@ mouse-3: go to end"))
   "Show the number of unread mails using mu. Requires mu4e-alert"
   mu4e-alert-mode-line
   :when (and active
-             (bound-and-true-p mu4e-alert-max-messages-to-process)))
+             (featurep 'mu4e-alert)))
 
 (provide 'spaceline-segments)
 

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -295,6 +295,7 @@ a function that returns a name to use.")
 (declare-function window-numbering-get-number 'window-numbering)
 (declare-function pyenv-mode-version 'pyenv-mode)
 (declare-function pyenv-mode-full-path 'pyenv-mode)
+(declare-function mu4e-alert-mode-line 'mu4e-alert)
 
 (spaceline-define-segment anzu
   "Show the current match number and the total number of matches.  Requires anzu
@@ -529,6 +530,12 @@ mouse-2: toggle rest visibility\n\
 mouse-3: go to end"))
   :when (and active
              (bound-and-true-p which-function-mode)))
+
+(spaceline-define-segment mu4e-alert-segment
+  "Show the number of unread mails using mu. Requires mu4e-alert"
+  mu4e-alert-mode-line
+  :when (and active
+             (bound-and-true-p mu4e-alert-max-messages-to-process)))
 
 (provide 'spaceline-segments)
 

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -533,7 +533,9 @@ mouse-3: go to end"))
 
 (spaceline-define-segment mu4e-alert-segment
   "Show the number of unread mails using mu. Requires mu4e-alert"
-  mu4e-alert-mode-line
+  (progn
+    (mu4e-alert-disable-mode-line-display)
+    mu4e-alert-mode-line)
   :when (and active
              (featurep 'mu4e-alert)))
 

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -533,11 +533,10 @@ mouse-3: go to end"))
 
 (spaceline-define-segment mu4e-alert-segment
   "Show the number of unread mails using mu. Requires mu4e-alert"
-  (progn
-    (mu4e-alert-disable-mode-line-display)
-    mu4e-alert-mode-line)
+  mu4e-alert-mode-line
   :when (and active
-             (featurep 'mu4e-alert)))
+             (featurep 'mu4e-alert))
+  :global-override ((:eval mu4e-alert-mode-line)))
 
 (provide 'spaceline-segments)
 


### PR DESCRIPTION
I am not really sure if the declare-function is okay, and the condition to check if mu4e-alert is actually installed checks for some random variable because I didn't find a fancy `mu4e-alert-mode` or something.