### PR TITLE
Allows the evil-state to be referenced directly from spaceline-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ that works for you.
 of the minor modes segment.
 
 - To get the mode-line highlight to change color depending on the evil state,
-set `spaceline-highlight-face-func` to `spaceline-highlight-face-evil-state`. 
+set `spaceline-highlight-face-func` to `spaceline-highlight-face-evil-state`.
 
 ## Medium tweaking
 
@@ -157,7 +157,7 @@ The full list of segments available, from left to right:
 - `persp-name`: integrates with `persp-mode`.
 - `workspace-number`: integrates with `eyebrowse`.
 - `window-number`: integrates with `window-numbering`.
-- `evil-state`: shows the current evil state, integrates with `evil`.
+- `evil-current-state`: shows the current evil state, integrates with `evil`.
 - `anzu`: integrates with `anzu`.
 - `auto-compile`: integrates with `auto-compile`.
 - `buffer-modified`: the standard marker denoting whether the buffer is modified
@@ -410,7 +410,7 @@ For example, this is the Spacemacs mode-line.
     (spaceline-install
 
      '(((persp-name workspace-number window-number)
-       :fallback evil-state
+       :fallback evil-current-state
        :separator "|"
        :face highlight-face)
       anzu

--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -67,7 +67,7 @@ ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
          '((persp-name
             workspace-number
             window-number)
-           :fallback evil-state
+           :fallback evil-current-state
            :separator "|"
            :face highlight-face)
          '(buffer-modified buffer-size buffer-id remote-host)

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -486,7 +486,7 @@ enabled."
                    (or flycheck-current-errors
                        (eq 'running flycheck-last-status-change)))))))
 
-(spaceline-define-segment evil-state
+(spaceline-define-segment evil-current-state
   "The current evil state.  Requires `evil-mode' to be enabled."
   (s-trim (evil-state-property evil-state :tag t))
   :when (bound-and-true-p evil-local-mode))


### PR DESCRIPTION
Rationale:
vim-powerline (the spacemacs layer) allows you to see what state you are
in visually (as a word). It looks something like this:
NORMAL > other stuff

This is well aligned with what vim does by default, and makes it very
easy to see what state you are in, even for states you haven't
encountered before. For spacemacs, there are a lot more states than
normal, insert, and visual.

As it was before this commit, you cannot use evil-state anywhere in your
spaceline, since it will simply refer to the previously defined
evil-state segment. I have tried
```lisp
(spaceline-install

  '(((evil-state window-number)
     :fallback evil-state
     :face highlight-face)
     anzu
  ;; etc from the default spacemacs settings
```

That didn't work, for the reasons mentioned above. I've renamed the
segment to evil-current-state. I'm open to other suggestions for that
name, it was the first thing I came up with.