### PR TITLE
Adds a new segment, `evil-state-full-word`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ that works for you.
 of the minor modes segment.
 
 - To get the mode-line highlight to change color depending on the evil state,
-set `spaceline-highlight-face-func` to `spaceline-highlight-face-evil-state`. 
+set `spaceline-highlight-face-func` to `spaceline-highlight-face-evil-state`.
 
 ## Medium tweaking
 
@@ -158,6 +158,7 @@ The full list of segments available, from left to right:
 - `workspace-number`: integrates with `eyebrowse`.
 - `window-number`: integrates with `window-numbering`.
 - `evil-state`: shows the current evil state, integrates with `evil`.
+- `evil-state-full-word`: shows the current evil state as a full word, integrates with `evil`.
 - `anzu`: integrates with `anzu`.
 - `auto-compile`: integrates with `auto-compile`.
 - `buffer-modified`: the standard marker denoting whether the buffer is modified

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -487,8 +487,13 @@ enabled."
                        (eq 'running flycheck-last-status-change)))))))
 
 (spaceline-define-segment evil-state
-  "The current evil state.  Requires `evil-mode' to be enabled."
+  "The current evil state as a tag. (e.g. <N>)  Requires `evil-mode' to be enabled."
   (s-trim (evil-state-property evil-state :tag t))
+  :when (bound-and-true-p evil-local-mode))
+
+(spaceline-define-segment evil-state-full-word
+  "The current evil state as a full word. (e.g. NORMAL)  Requires `evil-mode' to be enabled."
+  (upcase (format "%s" evil-state))
   :when (bound-and-true-p evil-local-mode))
 
 (defface spaceline-python-venv


### PR DESCRIPTION
This commit adds a new segment, evil-state-full-word. The previous
evil-state segment gives `<N>` for normal, `<I>` for insert, etc. This
segment gives `NORMAL` for normal, and `INSERT` for insert.