### PR TITLE
use powerline-buffer-id-inactive face for inactive windows

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -83,7 +83,7 @@
 
 (spaceline-define-segment buffer-id
   "Name of buffer."
-  (s-trim (powerline-buffer-id 'mode-line-buffer-id)))
+  (s-trim (powerline-buffer-id (if active 'mode-line-buffer-id 'mode-line-buffer-id-inactive))))
 
 (spaceline-define-segment remote-host
   "Hostname for remote buffers."


### PR DESCRIPTION
reflect milkypostman/powerline#122

This allows to set a specific face for the buffer-id when the window is inactive.

By default in powerline, `mode-line-buffer-id-inactive` inherits from `mode-line-buffer-id`, so unless this face is explicitly modified users will not see a difference.
