### PR TITLE
Remove compilation warning

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -23,6 +23,8 @@
 
 (require 'spaceline-segments)
 
+(defvar helm-ag-show-status-function)
+
 (defun spaceline--theme (left second-left &rest additional-segments)
   "Convenience function for the spacemacs and emacs themes."
   (spaceline-install `(,left


### PR DESCRIPTION
On Emacs 24.5, I get a warning when `helm-ag-show-status-function` is `setq`d without any declaration.
