### PR TITLE
Display page numbers in pdf-view-mode

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -141,9 +141,18 @@
   "The current column number."
   "%2c")
 
+(defun spaceline--pdfview-page-number ()
+  (format "(%d/%d)"
+	  (pdf-view-current-page)
+	  (pdf-cache-number-of-pages)))
+
 (spaceline-define-segment line-column
-  "The current line and column numbers."
-  "%l:%2c")
+  "The current line and column numbers, or `(current page/number of pages)`
+in pdf-view mode (enabled by the `pdf-tools' package)."
+  (if (eq 'pdf-view-mode major-mode)
+      (spaceline--pdfview-page-number)
+    "%l:%2c"))
+
 
 (spaceline-define-segment buffer-position
   "The current approximate buffer position, in percent."


### PR DESCRIPTION
Display "(\<current page\>/\<total pages\>)" instead of line-column
information in pdf-view-mode (provided by the pdf-tools package).

Line-column information originally did not really work in that mode
anyways.