### PR TITLE
New segment for `tracking-mode`.

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,6 +117,12 @@ and notifications from it.
 *** ERC
 [[http://www.emacswiki.org/emacs/ERC][ERC]] is an IRC client built in to Emacs. Spaceline shows channels with new
 messages if you have =erc-track= turned on.
+*** Circe
+[[https://github.com/jorgenschaefer/circe][Circe]] is another IRC client for Emacs; it also provides a generic API for
+listing modified buffers called =tracking-mode=.
+
+Spaceline shows channels with new messages if you have =tracking-mode= turned
+on; use =C-c C-SPC= to cycle through modified tracked buffers.
 
 *** Org
 Spaceline shows the currently clocking [[http://orgmode.org/][org-mode]] task.

--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -36,6 +36,7 @@
                 (minor-modes :when active)
                 (mu4e-alert-segment :when active)
                 (erc-track :when active)
+                (tracking-mode :when active :separator "")
                 (version-control :when active)
                 (org-pomodoro :when active)
                 (org-clock :when active)

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -328,6 +328,7 @@ a function that returns a name to use.")
 (declare-function window-numbering-get-number 'window-numbering)
 (declare-function pyenv-mode-version 'pyenv-mode)
 (declare-function pyenv-mode-full-path 'pyenv-mode)
+(declare-function tracking-mode 'tracking)
 
 (spaceline-define-segment projectile-root
   "Show the current projectile root."
@@ -354,6 +355,13 @@ package."
   (when (bound-and-true-p erc-track-mode)
     (mapcar (lambda (b) (buffer-name (car b)))
             erc-modified-channels-alist)))
+
+(spaceline-define-segment tracking-mode
+  "Show names of tracked buffers with changes.
+
+Requires that `tracking-mode' is enabled."
+  (when (bound-and-true-p tracking-mode)
+    tracking-mode-line-buffers))
 
 (defun spaceline--fancy-battery-percentage ()
   "Return the load percentage or an empty string."


### PR DESCRIPTION
`tracking-mode` is the generic API for reporting on modified buffers
used by the Circe Emacs IRC client.