### PR TITLE
pdf-view-current-page is a macro, eval for pg #

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -146,7 +146,7 @@
 
 (defun spaceline--pdfview-page-number ()
   (format "(%d/%d)"
-	  (pdf-view-current-page)
+	  (eval (pdf-view-current-page))
 	  (pdf-cache-number-of-pages)))
 
 (spaceline-define-segment line-column


### PR DESCRIPTION
### This is a copy of my comment for commit 8c20d0b, correcting an error from pull request #88 

**Problem**: When opening a .pdf file in Spacemacs, with the pdf-tools layer enabled, the modeline (spaceline) breaks because it attempts to call `pdf-view-current-page` as a function, which is not the intended behavior for `pdf-view-current-page`. 

As indicated in the pdf-tools source, as well as [issue #210 on pdf-tools](https://github.com/politza/pdf-tools/issues/210), `pdf-view-current-page` is a macro, not a function. As a result, spaceline will spit out a stream of `invalid-function` error messages while navigating a .pdf document.

**Solution**: Instead of invoking `pdf-view-current-page` as a function, we `eval` the macro that is `pdf-view-current-page`, which returns the correct .pdf page number and restores spaceline functionality in .pdf files where pdf-tools is used.