### PR TITLE
add support for winum.el window numbers

### DIFF
--- a/README.org
+++ b/README.org
@@ -89,15 +89,15 @@ theme will show the current workspace number. The Emacs theme uses the workspace
 number as a fallback for the perspective name: thus if persp-mode is installed,
 the Eyebrowse workspace will not be shown.
 
-*** Window-numbering
-[[https://github.com/nschum/window-numbering.el][Window-numbering]] shows a number for each window, and it works with both themes.
+*** Winum
+[[https://github.com/deb0ch/winum.el][Winum]] shows a number for each window, and it works with both themes.
 
-To make this package work, you have to override its own modeline display
-function:
+To prevent =winum= from inserting its own number in the mode-line, you have to
+set =winum-auto-setup-mode-line= to nil before activating =winum-mode=:
 
 #+BEGIN_SRC emacs-lisp
-  (defun window-numbering-install-mode-line (&optional position)
-    "Do nothing.")
+(setq winum-auto-setup-mode-line nil)
+(winum-mode)
 #+END_SRC
 
 *** Auto-compile

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -325,6 +325,7 @@ a function that returns a name to use.")
 (declare-function nyan-create 'nyan-mode)
 (declare-function safe-persp-name 'persp-mode)
 (declare-function get-frame-persp 'persp-mode)
+(declare-function winum-get-number 'winum)
 (declare-function window-numbering-get-number 'window-numbering)
 (declare-function pyenv-mode-version 'pyenv-mode)
 (declare-function pyenv-mode-full-path 'pyenv-mode)
@@ -443,16 +444,23 @@ This segment overrides the modeline functionality of `org-pomodoro' itself."
    ((string= "7" str) "➐")
    ((string= "8" str) "➑")
    ((string= "9" str) "➒")
-   ((string= "0" str) "➓")))
+   ((string= "10" str) "➓")
+   (t str)))
 
 (defvar spaceline-window-numbers-unicode nil
   "Set to true to enable unicode display in the `window-number' segment.")
 
 (spaceline-define-segment window-number
-  "The current window number. Requires `window-numbering-mode' to be enabled."
-  (when (bound-and-true-p window-numbering-mode)
-    (let* ((num (window-numbering-get-number))
-           (str (when num (int-to-string num))))
+  "The current window number.
+Requires either `winum-mode' or `window-numbering-mode' to be enabled."
+  (let* ((num (cond
+               ((bound-and-true-p winum-mode)
+                (winum-get-number))
+               ((bound-and-true-p window-numbering-mode)
+                (window-numbering-get-number))
+               (t nil)))
+         (str (when num (int-to-string num))))
+    (when num
       (if spaceline-window-numbers-unicode
           (spaceline--unicode-number str)
         (propertize str 'face 'bold)))))


### PR DESCRIPTION
[winum.el](https://github.com/deb0ch/winum.el) is a rewrite of [window-numbering.el](https://github.com/nschum/window-numbering.el) that heavily extends it.

Among other things, it allows for sharing numbers across multiple frames, allowing to switch windows more smoothly on multi-screen.

It also brings a lot of other features and adapts the package to how we use it in Spacemacs.

If, like I seem to remember, you are a multi-screen user then you might like it :smile_cat: 

A PR is coming soon to Spacemacs, and it is [on its way to be published on Melpa](https://github.com/melpa/melpa/pull/4451).