### PR TITLE
Fix which-function segment

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -595,6 +595,7 @@ and total packages"
     (let* ((current (format-mode-line which-func-current)))
       (when (string-match "{\\(.*\\)}" current)
         (setq current (match-string 1 current)))
+      (setq current (replace-regexp-in-string "%" "%%" current))
       (propertize current
                   'local-map which-func-keymap
                   'face 'which-func


### PR DESCRIPTION
which-function strings may contain percent characters, which we don’t want
expanded in the mode-line.