### PR TITLE
Higher priority for essential segments in narrow windows

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -54,7 +54,7 @@
         point-position
         line-column)
        :separator " | "
-       :priority 96)
+       :priority 100)
       (global :when active)
       ,@additional-segments
       (buffer-position :priority 99)


### PR DESCRIPTION
For verry narrow windows, the information most usefull (at least how I see it) is:
- `evil-state` - to display the vim mode I'm in
- `line-column` - to see where exactly I am in the buffer

This PR increases their priority so that they are always displayed. I've also increased the priority of `buffer-position`, although it's not really critial, it does make the UI look consistent when a window changes focus.

This feels a bit hackish, going below 0 on priority number, but setting them to 0 is still not enough, I am open to suggestions on how to better handle this.

See the images below for a demonstration. This shows a rather extreme example, but I have another laptop with lower resolution that hides the `line-column` segment with neotree and 2 vertical splits open, which is kind of bad since this is a rather commonly used layout.

Before
![before](https://user-images.githubusercontent.com/3746963/28768784-a354d65a-75e1-11e7-8ab1-d50bc3dd3fa0.png)

After:
![after](https://user-images.githubusercontent.com/3746963/28768795-aeff91d4-75e1-11e7-8f29-d779351598fb.png)
