### PR TITLE
Limit visual length of the buffer-id segment

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -81,9 +81,16 @@
   "Size of buffer."
   (powerline-buffer-size))
 
+(defcustom spaceline-buffer-id-max-length 45
+  "The maximum displayed length of the buffer-id segment."
+  :type 'boolean
+  :group 'spaceline)
+
 (spaceline-define-segment buffer-id
   "Name of buffer."
-  (s-trim (powerline-buffer-id 'mode-line-buffer-id)))
+  (s-trim (spaceline--string-trim-from-center
+           (powerline-buffer-id 'mode-line-buffer-id)
+           spaceline-buffer-id-max-length)))
 
 (spaceline-define-segment remote-host
   "Hostname for remote buffers."

--- a/spaceline.el
+++ b/spaceline.el
@@ -752,6 +752,16 @@ the changes to take effect."
     (when (spaceline--mode-line-nonempty global)
       (string-trim (powerline-raw global)))))
 
+(defun spaceline--string-trim-from-center (str len)
+  "Return STR with its center chars trimmed for it to be a maximum length of LEN.
+When characters are trimmed, they are replaced with '...'."
+  (if (> (length str) len)
+      (let ((mid (/ (- len 3) 2)))
+        (concat (substring str 0 mid)
+                (apply #'propertize "..." (text-properties-at (- mid 1) str))
+                (substring str (- (1+ mid)) nil)))
+    str))
+
 (provide 'spaceline)
 
 ;;; spaceline.el ends here


### PR DESCRIPTION
Hey,

This is a way of fixing the buffer-id taking up all the spaceline and hiding essential segments.

A too long buffer-id will be made shorter in the following fashion:

`01-much-too-too-long-buffer-id-taking-up-too-much-space-03.lol`

will become:

`01-much-too-too-long-...too-much-space-03.lol`

Keeping both ends of the filename is important because when files are named similarly, the difference in names lies most often either at the beginning or at the end of the name.

The default length limit is a customizable 45, that I chose completely arbitrarily.

This fixes #157, #151, #147, #149, and most importantly can replace #150.