### PR TITLE
more sensible priorities

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -27,37 +27,38 @@
   "Convenience function for the spacemacs and emacs themes."
   (spaceline-install
     `(,left
-      (anzu :priority 4)
+      (anzu :priority 95)
       auto-compile
       ,second-left
-      major-mode
+      (major-mode :priority 79)
       (process :when active)
       ((flycheck-error flycheck-warning flycheck-info)
        :when active
-       :priority 3)
-      (minor-modes :when active)
+       :priority 89)
+      (minor-modes :when active
+                   :priority 9)
       (mu4e-alert-segment :when active)
       (erc-track :when active)
       (version-control :when active
-                       :priority 7)
+                       :priority 78)
       (org-pomodoro :when active)
       (org-clock :when active)
       nyan-cat)
     `(which-function
       (python-pyvenv :fallback python-pyenv)
-      purpose
+      (purpose :priority 94)
       (battery :when active)
-      (selection-info :priority 2)
+      (selection-info :priority 95)
       input-method
       ((buffer-encoding-abbrev
         point-position
         line-column)
        :separator " | "
-       :priority 3)
+       :priority 96)
       (global :when active)
       ,@additional-segments
-      (buffer-position :priority 0)
-      (hud :priority 0)))
+      (buffer-position :priority 99)
+      (hud :priority 99)))
 
   (setq-default mode-line-format '("%e" (:eval (spaceline-ml-main)))))
 
@@ -72,9 +73,9 @@ ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
             window-number)
            :fallback evil-state
            :face highlight-face
-           :priority 0)
+           :priority 100)
          '((buffer-modified buffer-size buffer-id remote-host)
-           :priority 5)
+           :priority 98)
          additional-segments))
 
 (defun spaceline-emacs-theme (&rest additional-segments)
@@ -89,9 +90,9 @@ ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
             buffer-modified
             buffer-size)
            :face highlight-face
-           :priority 0)
+           :priority 100)
          '((buffer-id remote-host)
-           :priority 5)
+           :priority 98)
          additional-segments))
 
 ;;; Helm custom mode

--- a/spaceline.el
+++ b/spaceline.el
@@ -666,7 +666,7 @@ Returns a truthy value if the visibility of any segment changed."
 Used as a predicate for `sort' in `spaceline--init-runtime'."
   (let ((first (spaceline--priority first-alist))
         (second (spaceline--priority second-alist)))
-    (> first second)))
+    (< first second)))
 
 (defmacro spaceline-define-segment (name value &rest props)
   "Define a modeline segment called NAME with value VALUE and properties PROPS.

--- a/spaceline.el
+++ b/spaceline.el
@@ -564,10 +564,10 @@ PRIORITY-SYMBOL is initialized with default value nil.
 
 See `spaceline--init-runtime' for more information."
   (let ((left (--map (spaceline--parse-segment-spec it
-                       (vector (or (plist-get props :priority) -1) 0 t))
+                       (vector (or (plist-get props :priority) 0) 0 t))
                      segments-left))
         (right (--map (spaceline--parse-segment-spec it
-                        (vector (or (plist-get props :priority) -1) 0 t))
+                        (vector (or (plist-get props :priority) 0) 0 t))
                       segments-right)))
     (eval `(defvar-local ,left-symbol nil "See `spaceline--declare-runtime'."))
     (set-default left-symbol left)


### PR DESCRIPTION
Giving it more thought, I came up with a more sensible way of defining priorities:

- Lower priority segments will be hidden first

and that's it. No need for more complexity. The way I first came up with was overly and unnecessarily complicated.

This way the default, 0, is the lowest currently defined priority but if somebody wants a segment even less shown than the default ones it is still possible by supplying negative priorities.

Assuming that if a segment was not given a priority, it means that we don't care about that segment all that much after all.