### PR TITLE
stop using alias for spaceline-compile

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -25,7 +25,7 @@
 
 (defun spaceline--theme (left second-left &rest additional-segments)
   "Convenience function for the spacemacs and emacs themes."
-  (spaceline-install
+  (spaceline-compile
     `(,left
       (anzu :priority 4)
       auto-compile
@@ -108,13 +108,13 @@ ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
   :global t
   (if spaceline-helm-mode
       (progn
-        (spaceline-install 'helm
+        (spaceline-compile 'helm
           '((helm-buffer-id :face highlight-face)
             helm-number
             helm-follow
             helm-prefix-argument)
           '(helm-help))
-        (spaceline-install 'helm-done
+        (spaceline-compile 'helm-done
           '(((helm-buffer-id helm-done) :face highlight-face)
             helm-number
             helm-follow
@@ -140,7 +140,7 @@ This minor mode requires info+."
   :global t
   (if spaceline-info-mode
       (progn
-        (spaceline-install 'info '(info-topic (info-nodes :separator " > ")) nil)
+        (spaceline-compile 'info '(info-topic (info-nodes :separator " > ")) nil)
         (defadvice Info-set-mode-line (after spaceline-info)
           "Set up a custom info modeline."
           (if (featurep 'info+)

--- a/spaceline.el
+++ b/spaceline.el
@@ -498,6 +498,8 @@ The supported properties are
 
 (defalias 'spaceline-install 'spaceline-compile)
 
+(make-obsolete-variable 'spaceline-install 'spaceline-compile "2.0.2")
+
 (defmacro spaceline--code-for-side
     (global-excludes runtime-symbol segments side)
   "Generate the code that will evaluate all segments for one side.


### PR DESCRIPTION
I find the mere existence of this alias confusing: why would we need two names for one function ?

Before seeing this `defalias`, I was sure that `spaceline-install` and `spaceline-compile` were two distinct functions doing (even slightly) different things, and couldn't believe my eyes when I saw that in fact, no.

What was your initial reason for defining this alias ?