### PR TITLE
Add a total-lines segment

### DIFF
--- a/README.org
+++ b/README.org
@@ -227,6 +227,8 @@ In addition, the following segments are defined, but are not used in the default
 themes.
 
 - =line=: current line.
+- =total-lines=: total number of lines.
+- =lines-position=: position in file based on line count.
 - =column=: current column.
 - =projectile-root=: root of current projectile project, integrates with
   =projectile=.

--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -57,7 +57,6 @@
        :priority 96)
       (global :when active)
       ,@additional-segments
-      (buffer-position :priority 99)
       (hud :priority 99)))
 
   (setq-default mode-line-format '("%e" (:eval (spaceline-ml-main)))))
@@ -67,7 +66,7 @@
   "Install the modeline used by Spacemacs.
 
 ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
-`buffer-position'."
+`lines-position'."
   (apply 'spaceline--theme
          '((persp-name
             workspace-number
@@ -75,9 +74,11 @@ ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
            :fallback evil-state
            :face highlight-face
            :priority 100)
-         '((buffer-modified buffer-size buffer-id remote-host)
+         '((buffer-modified total-lines buffer-id remote-host)
            :priority 98)
-         additional-segments))
+         (list
+          additional-segments
+          '(lines-position :priority 99))))
 
 ;;;###autoload
 (defun spaceline-emacs-theme (&rest additional-segments)
@@ -95,7 +96,9 @@ ADDITIONAL-SEGMENTS are inserted on the right, between `global' and
            :priority 100)
          '((buffer-id remote-host)
            :priority 98)
-         additional-segments))
+         (list
+          additional-segments
+          '(buffer-position :priority 99))))
 
 ;;; Helm custom mode
 ;;  ================

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -144,6 +144,33 @@
   "The current line number."
   "%l")
 
+(spaceline-define-segment total-lines
+  "The total number of lines."
+  (when (bound-and-true-p total-lines-mode)
+    (format "%d" total-lines)))
+
+(spaceline-define-segment lines-position
+  "The current position in the buffer based on the line count."
+  (when (bound-and-true-p total-lines-mode)
+    (save-excursion
+      (save-restriction
+        (widen)
+        (let ((current-line (line-number-at-pos))
+              (window-top-line (progn
+                                        (move-to-window-line 0)
+                                        (line-number-at-pos)))
+              (window-bottom-line (progn
+                                           (move-to-window-line -1)
+                                           (line-number-at-pos))))
+          (cond ((and (= window-top-line 1)
+                      (= window-bottom-line total-lines))
+                 "All")
+                 ((= window-top-line 1) "Top")
+                 ((= window-bottom-line total-lines) "Bottom")
+                 (t (format
+                     "%2d%%%%"
+                     (* 100 (/ current-line (float total-lines)))))))))))
+
 (spaceline-define-segment column
   "The current column number."
   "%2c")


### PR DESCRIPTION
This is equivalent to `%L` in Vim's status line.

Uses https://melpa.org/#/total-lines