### PR TITLE
Add recursive-edit, macrodef segments

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -620,6 +620,11 @@ mouse-3: go to end"))))
   (format "↻%s" (recursion-depth))
   :when (> (recursion-depth) 0))
 
+(spaceline-define-segment macrodef
+  "Shows when defining a keyboard macro."
+  "•REC"
+  :when defining-kbd-macro)
+
 (provide 'spaceline-segments)
 
 ;;; spaceline-segments.el ends here

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -615,6 +615,11 @@ mouse-3: go to end"))))
     mu4e-alert-mode-line)
   :global-override ((:eval mu4e-alert-mode-line)))
 
+(spaceline-define-segment recursive-edit
+  "Shows the current recursive-edit depth."
+  (format "↻%s" (recursion-depth))
+  :when (> (recursion-depth) 0))
+
 (provide 'spaceline-segments)
 
 ;;; spaceline-segments.el ends here


### PR DESCRIPTION
- recursive-edit state is normally indicated in the vanilla mode-line using brackets
- macro recording state is part of `minor-mode-alist`, but might be useful to have for users who disable
  the minor modes segment