### PR TITLE
Remove overwrite of toggle vars value when defining segments

### DIFF
--- a/spaceline.el
+++ b/spaceline.el
@@ -765,8 +765,6 @@ the changes to take effect."
     `(progn
        (defvar ,toggle-var ,enabled
          ,(format "True if modeline segment %S is enabled." name))
-       ;; In case the segment is redefined, we explicitly set the toggle
-       (setq ,toggle-var ,enabled)
 
        (defun ,toggle-func () (interactive) (setq ,toggle-var (not ,toggle-var)))
        (defun ,toggle-func-on () (interactive) (setq ,toggle-var t))


### PR DESCRIPTION
Hi Eivind,

I recently deferred spaceline loading to improve Spacemacs startup feel. This seems to really works well except that it makes it harder for end users to enable/disable segments.

This commit privileges end users use cases instead of developers use cases when
it comes to Spaceline configuration. Explanation below:

This setq prevents easy setup of toggle variables when the mode line is lazy
loaded.

The natural way for a spacemacs user to disable a segment is to set the variable
or use the toggle functions. It should always work (actually toggle functions won't be available at that point, so they should use the variable).

For spaceline developers creating new segments they should be aware of the
toggle variables and set them manually for the current session.

Cheers,
Sylvain