### PR TITLE
Don't display projectile segment when no project name

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -349,7 +349,8 @@ The cdr can also be a function that returns a name to use.")
   "Show the current projectile root."
   (when (fboundp 'projectile-project-name)
     (let ((project-name (projectile-project-name)))
-      (unless (string= project-name (buffer-name))
+      (unless (or (string= project-name "-")
+                  (string= project-name (buffer-name)))
         project-name))))
 
 (spaceline-define-segment anzu


### PR DESCRIPTION
When there is no project, `projectile-project-name' doesn't return nil
but "-".