### PR TITLE
Color the modeline according to the current God state

### DIFF
--- a/README.org
+++ b/README.org
@@ -144,6 +144,14 @@ include any information from Evil.
 You can color the modeline according to the current Evil state by setting
 =spaceline-highlight-face-func= to =spaceline-highlight-face-evil-state=.
 
+*** God
+[[https://github.com/chrisdone/god-mode/][God]] is a global minor mode for entering Emacs commands without
+modifier keys.  It's similar to Vim's separation of commands and
+insertion mode.
+
+You can color the modeline according to the current God state by setting
+=spaceline-highlight-face-func= to =spaceline-highlight-face-god-state=.
+
 ** Troubleshooting
 There are a number of reasons why Spaceline might look different on your setup
 compared to Spacemacs proper. Some of the most important ones are addressed here.
@@ -261,6 +269,8 @@ course you can write your own:
   current evil state. The face corresponding to each state is determined by the
   association list =spaceline-evil-state-faces=, which contains default values
   for the standard evil states. (Spacemacs has a few more.)
+- =spaceline-highlight-face-god-state=: Chooses a face determined by the
+  current god state.
 - =spaceline-highlight-face-modified=: Chooses a face determined by the status
   of the current buffer (modified, unmodified or read-only).
 

--- a/spaceline.el
+++ b/spaceline.el
@@ -142,6 +142,8 @@ default configuration."
              (spaceline-evil-replace "chocolate" "Evil replace state face.")
              (spaceline-evil-visual "gray" "Evil visual state face.")
              (spaceline-evil-motion "plum3" "Evil motion state face.")
+             (spaceline-god-inactive "DarkGoldenrod2" "God inactive state face.")
+             (spaceline-god-active "VioletRed" "God active state face.")
              (spaceline-unmodified "DarkGoldenrod2" "Unmodified buffer face.")
              (spaceline-modified "SkyBlue2" "Modified buffer face.")
              (spaceline-read-only "plum3" "Read-only buffer face.")))
@@ -177,6 +179,15 @@ Set `spaceline-highlight-face-func' to
              (face (assq state spaceline-evil-state-faces)))
         (if face (cdr face) (spaceline-highlight-face-default)))
     (spaceline-highlight-face-default)))
+
+(defun spaceline-highlight-face-god-state ()
+  "Set
+the highlight face depending on the god state.
+Set `spaceline-highlight-face-func' to
+`spaceline-highlight-face-god-state' to use this."
+  (cond
+    (god-local-mode 'spaceline-god-active)
+    (t 'spaceline-god-inactive)))
 
 (defun spaceline-highlight-face-modified ()
   "Set the highlight face depending on the buffer modified status.


### PR DESCRIPTION
Hi!

This is a small patch which allows the user to visually discern the current God mode by coloring the spaceline (similar to coloring by Evil state).  Very handy... :)

Martin