### PR TITLE
Added a simplified spaceline segment for version control

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -107,6 +107,21 @@
   (when (spaceline--mode-line-nonempty mode-line-process)
     (s-trim (powerline-raw mode-line-process))))
 
+(spaceline-define-segment version-control-simple
+  "Simplified version control information."
+  (when vc-mode
+    (powerline-raw
+     (when (buffer-file-name)
+       (pcase (vc-state (buffer-file-name))
+         (`up-to-date " ")
+         (`ignored " ")
+         (`edited "~")
+         (`added "+")
+         (`removed "-")
+         (`needs-merge "!")
+         (`needs-update "!")
+         (_ "?"))))))
+
 (spaceline-define-segment version-control
   "Version control information."
   (when vc-mode


### PR DESCRIPTION
This commit adds a new segment `version-control-simple`, which is
essentially a minimalist version of the `version-control` segment. 

In contrast to the existing version control segment, this version:
- Does not show what VCS system you're using;
- Does not show what branch you're working on;
- Reduces the VCS status to one character.

I think this is especially useful as an option right after `buffer-id` in the
modeline. You then get a single character `+` (addition), `-` (removal),
`~` (edited), `!` (needs action), or `?` (other) right after the filename.