### PR TITLE
always show the hud segment

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -245,8 +245,7 @@ segment.  Otherwise only show the active input method, if any."
 
 (spaceline-define-segment hud
   "A HUD that shows which part of the buffer is currently visible."
-  (when (string-match "\%" (format-mode-line "%p"))
-    (powerline-hud highlight-face default-face))
+  (powerline-hud highlight-face default-face)
   :tight t)
 
 ;;; Helm segments


### PR DESCRIPTION
otherwise, the modeline height jumps to be less when the hud segment is no longer rendered.

this happens because the hud element defines the spaceline height for me on emacs29, without the hud modeline height appears to be determined by the modeline face only.