### PR TITLE
buffer-id: Trim whitespace before trimming from center

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -90,9 +90,9 @@
 
 (spaceline-define-segment buffer-id
   "Name of buffer."
-  (s-trim (spaceline--string-trim-from-center
-           (powerline-buffer-id (if active 'mode-line-buffer-id 'mode-line-buffer-id-inactive))
-           spaceline-buffer-id-max-length)))
+  (spaceline--string-trim-from-center
+   (s-trim (powerline-buffer-id (if active 'mode-line-buffer-id 'mode-line-buffer-id-inactive)))
+   spaceline-buffer-id-max-length))
 
 (spaceline-define-segment remote-host
   "Hostname for remote buffers."


### PR DESCRIPTION
When the buffer name is exactly `spaceline-buffer-id-max-length` long, after powerline-buffer-id prepends a space, trimming from the center and then trimming whitespace will unnecessarily replace some of the buffer name with `...`.