### PR TITLE
fix(spaceline-segments.el): Ensure the minor menu opens on L/R click

### DIFF
--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -58,13 +58,13 @@
                                      "\nmouse-3: Toggle minor mode")
                   'local-map (let ((map (make-sparse-keymap)))
                                (define-key map
-                                 [mode-line down-mouse-1]
+                                 [mode-line mouse-1]
                                  (powerline-mouse 'minor 'menu lighter))
                                (define-key map
                                  [mode-line mouse-2]
                                  (powerline-mouse 'minor 'help lighter))
                                (define-key map
-                                 [mode-line down-mouse-3]
+                                 [mode-line mouse-3]
                                  (powerline-mouse 'minor 'menu lighter))
                                (define-key map
                                  [header-line down-mouse-3]


### PR DESCRIPTION
Hi @TheBB
I'm a teacher and co-maintainer of several modes, and I happen to recently adopt `spaceline`, which is really great BTW!
I noticed that the minor mode menu does not show up on mouse-1 / mouse-3 click.
Hence this patch that I tested successfully in GUI context and TTY (`emacs -nw`) with `(xterm-mouse-mode)`.

FWIW, I'm using GNU Emacs 27.1 on Debian 11, with this init file:
https://github.com/erikmd/tapfa-init.el/blob/master/.emacs