### PR TITLE
Treesit segment

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -37,6 +37,7 @@
        :priority 89)
       (minor-modes :when active
                    :priority 9)
+      (treesit-inspect :when active)
       (mu4e-alert-segment :when active)
       (erc-track :when active)
       (version-control :when active

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -695,6 +695,11 @@ mouse-3: go to end"))))
   "•REC"
   :when defining-kbd-macro)
 
+(spaceline-define-segment treesit-inspect
+  "Show tree-sitter node at point."
+  (when (and active (treesit-available-p) treesit-inspect-mode)
+    '((:eval treesit--inspect-name))))
+
 (provide 'spaceline-segments)
 
 ;;; spaceline-segments.el ends here


### PR DESCRIPTION
Emacs 29 has introduced a new minor mode called `treesit-inspect-mode` that adds its mode line modifications to `mode-line-misc-info`. Since there's no Spaceline segment that displays `mode-line-misc-info`, this segment has to be recreated in Spaceline.