### PR TITLE
so-long segment

### DIFF
--- a/spaceline-config.el
+++ b/spaceline-config.el
@@ -56,6 +56,7 @@
         line-column)
        :separator " | "
        :priority 96)
+      (so-long :when active)
       (global :when active)
       ,@additional-segments
       (buffer-position :priority 99)

--- a/spaceline-segments.el
+++ b/spaceline-segments.el
@@ -702,6 +702,12 @@ mouse-3: go to end"))))
   (when (and active (treesit-available-p) treesit-inspect-mode)
     '((:eval treesit--inspect-name))))
 
+(spaceline-define-segment so-long
+  "Show `so-long-mode-line-info'."
+  (when (and active
+             (bound-and-true-p so-long-mode-line-info))
+    '(("" so-long-mode-line-info))))
+
 (provide 'spaceline-segments)
 
 ;;; spaceline-segments.el ends here


### PR DESCRIPTION
For the same reason as #238, `so-long-mode` adds its mode line modifications to `mode-line-misc-info`, but there's no Spaceline segment that displays `mode-line-misc-info`, this segment has to be recreated in Spaceline.

